### PR TITLE
Corrige le calcul du DTES réel

### DIFF
--- a/front/src/app/components/referentiel-calculator/referentiel-calculator.component.ts
+++ b/front/src/app/components/referentiel-calculator/referentiel-calculator.component.ts
@@ -100,7 +100,7 @@ export class ReferentielCalculatorComponent
 
     this.realCoverage = fixDecimal(this.totalOut / this.totalIn);
     this.realDTESInMonths = fixDecimal(
-      this.totalStock / this.totalOut / this.nbMonth
+      this.totalStock / this.totalOut
     );
 
     this.getHRPositions();


### PR DESCRIPTION
Il restait une division en trop à cet endroit que nous n'avions plus besoin de faire car nous utilisons maintenant des sorties moyennes sur la periode